### PR TITLE
bugfix for initializing an affine transformation

### DIFF
--- a/libraries/msm-newmeshreg/src/mesh_registration.cpp
+++ b/libraries/msm-newmeshreg/src/mesh_registration.cpp
@@ -139,7 +139,7 @@ newresampler::Mesh Mesh_registration::project_CPgrid(newresampler::Mesh SPH_in, 
             else
             {
                 newresampler::sphere_project_warp(SPH_in, MESHES[num], transformed_mesh, _numthreads);
-                model->warp_CPgrid(MESHES[num],transformed_mesh, num);
+                if (model) model->warp_CPgrid(MESHES[num],transformed_mesh, num);
             }
         }
     }


### PR DESCRIPTION
There's a scenario where initializing a new alignment with a previous alignment leads to a segfault. The conditions needed to reproduce this seem to be simply that the second alignment include an initial affine step. The cause is the invocation of `model` on line 142 of libraries/msm-newmeshreg/src/mesh_registration.cpp. `model` is created when the alignment method is DISCRETE (line 82). However, if the first level is AFFINE or RIGID, then model is not created (see lines 69-73), and if a `transformed_mesh` is also provided, then model gets invoked on line 142 leading to a segfault. This is a regression bug introduced in commit aea7e11 on April 11, 2024 (v0.6.2 seems to be the last release free of this error). At the time a guard existed on line 142 to ensure the pointer wasn't dereferenced when null.

To replicate this bug you can use HCP data and the HCP configs. I've slightly modified MSMAllStrainFinalconf1to1_1to3_1 below to include an initial AFFINE step. This scenario may matter when using different alignment modalities, e.g. initializing on anatomy and then aligning on noisier functional data.

```
FSLDIR=<path to FSL root> # this is just your conda install root if you're using the conda build of fsl

# modify to point to your directory containing the HCP S1200 data
HCPDIR=/dartfs/rc/lab/D/DBIC/DBIC/archive/HCP/HCP1200/
SID1=101107
SID2=202820

newmsm --inmesh=$HCPDIR/$SID2/MNINonLinear/Native/$SID2.L.sphere.native.surf.gii \
    --out=MSMSulc.L. --refmesh=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sphere.native.surf.gii \
    --indata=$HCPDIR$SID2/MNINonLinear/Native/$SID2.L.sulc.native.shape.gii \
    --refdata=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sulc.native.shape.gii \
    --conf=$FSLDIR/etc/MSM/HCP_multimodal_alignment/MSMSulcStrainFinalconf \
    --verbose

# MSMAllStrainFinalconf1to1_1to3_1 modified to include an initial AFFINE step
cat<< END>newconf
--simval=1,2,2,2
--sigma_in=0,0,0,0
--sigma_ref=0,0,0,0
--lambda=10,0.00001,0.0075,0.01
--it=10,10,15,15
--opt=AFFINE,DISCRETE,DISCRETE,DISCRETE
--CPgrid=4,2,3,4
--SGgrid=6,4,5,6
--datagrid=6,4,5,6
--regoption=3
--regexp=2
--dopt=HOCR
--VN
--rescaleL
--triclique
--k_exponent=2
--bulkmod=1.6
--shearmod=0.4
END
    
newmsm --inmesh=$HCPDIR/$SID2/MNINonLinear/Native/$SID2.L.sphere.native.surf.gii \
    --out=MSMSulc.L. --refmesh=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sphere.native.surf.gii \
    --indata=$HCPDIR$SID2/MNINonLinear/Native/$SID2.L.sulc.native.shape.gii \
    --refdata=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sulc.native.shape.gii \
    --trans=MSMSulc.L.sphere.reg.surf.gii \
    --conf=newconf \
    --verbose
    
```

The second invocation of newmsm v1.0 will produce this output:
```
newmsm --inmesh=$HCPDIR/$SID2/MNINonLinear/Native/$SID2.L.sphere.native.surf.gii     --out=MSMSulc.L. --refmesh=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sphere.native.surf.gii     --indata=$HCPDIR$SID2/MNINonLinear/Native/$SID2.L.sulc.native.shape.gii     --refdata=$HCPDIR$SID1/MNINonLinear/Native/$SID1.L.sulc.native.shape.gii     --trans=MSMSulc.L.sphere.reg.surf.gii     --conf=newconf     --verbose
This is newMSM v1.0.

Parameters:
Optimiser per level: AFFINE DISCRETE DISCRETE DISCRETE 
Similarity measure per level: 1 2 2 2 
Max iterations per level: 10 10 15 15 
Lambda regulariser: 10 1e-05 0.0075 0.01 
Sigma for in data per level: 0 0 0 0 
Sigma for ref data per level: 0 0 0 0 
Datagrid resolution per level: 6 4 5 6 
CP grid resolution per level 4 2 3 4 
Sampling grid resolution per level: 6 4 5 6 
Rigid parameters: Affine step size: 0.01 Affine grad sampling: 0.5
Variance normalise set.
Triclique likelihood.
Rescale labels set.
Discrete implementation: HOCR
Regulariser: 3
Shearmod: 0.4; Bulkmod: 1.6; k_exponent: 2
Regulariser exponent: 2
Number of execution threads: 32


Starting multiresolution with 4 levels.
Initialising level 1
Segmentation fault (core dumped)

```

This pull request fixes it by reintroducing the guard on line 142.
